### PR TITLE
Use a more flexible rubygem requirement syntax (bnc#895069)

### DIFF
--- a/package/yast2-nfs-client.changes
+++ b/package/yast2-nfs-client.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Sep  4 12:23:22 UTC 2014 - mvidner@suse.com
+
+- Use a more flexible rubygem requirement syntax (bnc#895069)
+- 3.1.9
+
+-------------------------------------------------------------------
 Wed Aug  6 12:36:27 UTC 2014 - ancor@suse.com
 
 - Don't display 'NFS Settings' tab when called from partitioner

--- a/package/yast2-nfs-client.spec
+++ b/package/yast2-nfs-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-nfs-client
-Version:        3.1.8
+Version:        3.1.9
 Release:        0
 Url:            https://github.com/yast/yast-nfs-client
 
@@ -38,7 +38,7 @@ BuildRequires:  yast2 >= 2.23.23
 # - "migration"
 # - "v4.1" v4.x
 BuildRequires:  nfs-client < 1.3.1
-BuildRequires:  rubygem-rspec
+BuildRequires:  rubygem(rspec)
 #ag_showexports moved to yast2 base
 # introduces extended IPv6 support.
 Requires:       yast2 >= 2.23.6


### PR DESCRIPTION
https://en.opensuse.org/openSUSE:Packaging_Ruby#Format_of_automatically_generated_Provides:_headers
