### PR TITLE
Fixed string substitution in a translated message

### DIFF
--- a/package/yast2-nfs-client.changes
+++ b/package/yast2-nfs-client.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Nov 18 07:32:59 UTC 2014 - lslezak@suse.cz
+
+- fixed string substitution in a translated message
+
+-------------------------------------------------------------------
 Fri Nov  7 17:00:31 CET 2014 - locilka@suse.com
 
 - Removed obsolete service (nfsboot) handling (bnc#867766)

--- a/src/modules/NfsOptions.rb
+++ b/src/modules/NfsOptions.rb
@@ -148,7 +148,7 @@ module Yast
         if non_value_option?(key)
           next if value.nil?
           # To translators: error popup
-          error_message = _("Unexpected value '#{value}' for option '#{key}'") % { :value => value, :key => key }
+          error_message = _("Unexpected value '%{value}' for option '%{key}'") % { :value => value, :key => key }
         # All unknown options
         elsif ! OPTIONS_WITH_VALUE.include?(key)
           # To translators: error popup


### PR DESCRIPTION
- Backport from `master` (after adding `rake check:pot` the Travis build fails for `SLE-12-GA` branch)
- Changes a translatable string but it didn't work correctly before the change, IMHO it's OK for SLE12 branch
