### PR TITLE
cleanup: use native Ruby "gsub" method

### DIFF
--- a/package/yast2-nfs-client.changes
+++ b/package/yast2-nfs-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jan 20 10:18:58 UTC 2015 - lslezak@suse.cz
+
+- cleanup: use native Ruby "gsub" method, removed our own
+  implementation
+- 3.1.13
+
+-------------------------------------------------------------------
 Thu Dec  4 09:50:30 UTC 2014 - jreidinger@suse.com
 
 - remove X-KDE-Library from desktop file (bnc#899104)

--- a/package/yast2-nfs-client.spec
+++ b/package/yast2-nfs-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-nfs-client
-Version:        3.1.12
+Version:        3.1.13
 Release:        0
 Url:            https://github.com/yast/yast-nfs-client
 

--- a/src/modules/Nfs.rb
+++ b/src/modules/Nfs.rb
@@ -263,9 +263,7 @@ module Yast
     # @param [String] s a string or nil
     # @return escaped string or nil
     def EscapeSpaces1(s)
-      s == nil ?
-        nil :
-        Builtins.mergestring(Builtins.splitstring(s, " "), "\\040")
+      s && s.gsub(" ", "\\\\040")
     end
 
     # Escape spaces " " -> "\\040" in all values of all entries
@@ -282,35 +280,12 @@ module Yast
       end }
     end
 
-    # (like awk gsub, but return the result, not number of replacements)
-    # replaces from back!
-    # @param [String] regex regular expression to replace
-    # @param [String] replacement the replacement string
-    # @param [String] s where to replace
-    # @return the changed string
-    def gsub(regex, replacement, s)
-      temp = nil
-      while true
-        # argh, regexpsub logs an error if it cannot sub
-        break if !Builtins.regexpmatch(s, Ops.add(Ops.add(".*", regex), ".*"))
-        temp = Builtins.regexpsub(
-          s,
-          Ops.add(Ops.add("(.*)", regex), "(.*)"),
-          Ops.add(Ops.add("\\1", replacement), "\\2")
-        )
-        break if temp == nil
-        s = temp
-      end
-      s
-    end
-
     # Un-escape spaces "\\040" -> " "
     # @param [String] s string or nil
     # @return escaped string or nil
     def UnescapeSpaces1(s)
-      # escaped space, \040, is /\\040/
-      # which is "\\\\040"
-      s == nil ? nil : gsub("\\\\040", " ", s)
+      # escaped space, \040 is "\\040"
+      s && s.gsub("\\040", " ")
     end
 
     # Un-escape spaces "\\040" -> " " in all values of all entries


### PR DESCRIPTION
removed our own implementation

- 3.1.13