### PR TITLE
Jenkins support

### DIFF
--- a/package/yast2-nfs-client.spec
+++ b/package/yast2-nfs-client.spec
@@ -41,6 +41,13 @@ Requires:       yast2-nfs-common >= 2.24.0
 # showmount, #150382, #286300
 Recommends:     nfs-client
 
+# Unfortunately we cannot move this to macros.yast,
+# bcond within macros are ignored by osc/OBS.
+%bcond_with yast_run_ci_tests
+%if %{with yast_run_ci_tests}
+BuildRequires: rubygem(yast-rake-ci)
+%endif
+
 Provides:       yast2-config-nfs
 Provides:       yast2-config-nfs-devel
 Obsoletes:      yast2-config-nfs


### PR DESCRIPTION
This is the Jenkins support for a simple autotools based module. The respective Jenkins build project is [yast-nfs-client-github-push](https://ci.opensuse.org/job/yast-nfs-client-github-push/).

Note: Check also the green check mark for the commit - there is a Jenkins build status result in addition to the Travis result. The link points to a build where also `rubocop` is executed (not used during normal RPM build in OBS).

Basically this is all what we need to change in YaST packages to switch from Travis to Jenkins.

(Note: so far only `master` based branches work correctly.)