### PR TITLE
Docker file cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
 FROM yastdevel/ruby:sle12-sp3
-RUN zypper --non-interactive update yast2
 COPY . /usr/src/app
 


### PR DESCRIPTION
 That `zypper` call is not needed now. I guess it was needed temporarily because of some OBS/Docker/... issues...
  