### PR TITLE
 Fixed package check and error handling (bsc#1079624)

### DIFF
--- a/package/yast2-nfs-client.changes
+++ b/package/yast2-nfs-client.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Feb 23 16:20:23 UTC 2018 - lslezak@suse.cz
+
+- During installation do not check whether the portmapper package
+  is installed, fixed error handling when scanning the NFS exports
+  fails (bsc#1079624)
+- 4.0.2
+
+-------------------------------------------------------------------
 Thu Feb  1 20:39:37 UTC 2018 - knut.anderssen@suse.com
 
 - Replace SuSEFirewall2 by firewalld (fate#323460)

--- a/package/yast2-nfs-client.spec
+++ b/package/yast2-nfs-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-nfs-client
-Version:        4.0.1
+Version:        4.0.2
 Release:        0
 Url:            https://github.com/yast/yast-nfs-client
 

--- a/src/modules/Nfs.rb
+++ b/src/modules/Nfs.rb
@@ -15,6 +15,7 @@ module Yast
 
       Yast.import "FileUtils"
       Yast.import "Mode"
+      Yast.import "Stage"
       Yast.import "NfsOptions"
       Yast.import "Report"
       Yast.import "Service"
@@ -558,8 +559,8 @@ module Yast
       end
 
       portmapper = FindPortmapper()
-      # check whether portmapper is installed
-      if IsPortmapperInstalled(portmapper) == false
+      # check whether portmapper is installed, skip the check in inst-sys
+      if !Stage.initial && IsPortmapperInstalled(portmapper) == false
         Builtins.y2warning("Neither rpcbind nor portmap is installed")
         return nil
       end
@@ -676,7 +677,7 @@ module Yast
     # Probe a server for its exports.
     # @param [String] server IP or hostname
     # @param [Boolean] v4 Use NFSv4?
-    # @return a list of exported paths
+    # @return [Array<String>, nil] a list of exported paths or nil on error
     def ProbeExports(server, v4)
       dirs = []
 
@@ -704,8 +705,7 @@ module Yast
         )
       end
 
-      dirs = ["internal error"] if dirs.nil?
-      deep_copy(dirs)
+      dirs
     end
 
     publish variable: :modified, type: "boolean"

--- a/test/nfs_options_test.rb
+++ b/test/nfs_options_test.rb
@@ -21,69 +21,71 @@ require_relative "spec_helper"
 
 Yast.import "NfsOptions"
 
-describe "#validate" do
-  it "returns empty string on correct options" do
-    [
-      "defaults",
-      "nolock,bg",
-      "nolock,nobg",
-      "nolock,rsize=8192",
-      "defaults,ro,noatime,nodiratime,users,exec"
-    ].each do |options|
-      returned = Yast::NfsOptions.validate(options)
-      expect(returned).to be_empty, "options '#{options}' returned '#{returned}'"
+describe "Yast::NfsOptions" do
+  describe "#validate" do
+    it "returns empty string on correct options" do
+      [
+        "defaults",
+        "nolock,bg",
+        "nolock,nobg",
+        "nolock,rsize=8192",
+        "defaults,ro,noatime,nodiratime,users,exec"
+      ].each do |options|
+        returned = Yast::NfsOptions.validate(options)
+        expect(returned).to be_empty, "options '#{options}' returned '#{returned}'"
+      end
     end
-  end
 
-  it "returns 'Empty option strings are not allowed' error message on empty options" do
-    returned = Yast::NfsOptions.validate("")
-    expect(returned).to start_with("Empty option strings are not allowed"), "options '' returned '#{returned}'"
-  end
-
-  it "returns 'Empty value' error message on options that expect key=value and the value is empty" do
-    [
-      "noatime,port=",
-      "mountvers=",
-      "mountvers,=port=23",
-      "nolock,rsize="
-    ].each do |options|
-      returned = Yast::NfsOptions.validate(options)
-      expect(returned).to start_with("Empty value"), "options '#{options}' returned '#{returned}'"
+    it "returns 'Empty option strings are not allowed' error message on empty options" do
+      returned = Yast::NfsOptions.validate("")
+      expect(returned).to start_with("Empty option strings are not allowed"), "options '' returned '#{returned}'"
     end
-  end
 
-  it "returns 'Unexpected value' error message on options that do not expect key=value but some value is present" do
-    [
-      "nolock,intr=bogus",
-      "nosuid=true"
-    ].each do |options|
-      returned = Yast::NfsOptions.validate(options)
-      expect(returned).to start_with("Unexpected value"), "options '#{options}' returned '#{returned}'"
+    it "returns 'Empty value' error message on options that expect key=value and the value is empty" do
+      [
+        "noatime,port=",
+        "mountvers=",
+        "mountvers,=port=23",
+        "nolock,rsize="
+      ].each do |options|
+        returned = Yast::NfsOptions.validate(options)
+        expect(returned).to start_with("Empty value"), "options '#{options}' returned '#{returned}'"
+      end
     end
-  end
 
-  it "returns 'Invalid option' error message on options that expect key=value and the value contains '='" do
-    [
-      "noatime,port=dort=fort",
-      "mountvers=port=23",
-      "nolock,retrans=trans=trans"
-    ].each do |options|
-      returned = Yast::NfsOptions.validate(options)
-      expect(returned).to start_with("Invalid option"), "options '#{options}' returned '#{returned}'"
+    it "returns 'Unexpected value' error message on options that do not expect any value" do
+      [
+        "nolock,intr=bogus",
+        "nosuid=true"
+      ].each do |options|
+        returned = Yast::NfsOptions.validate(options)
+        expect(returned).to start_with("Unexpected value"), "options '#{options}' returned '#{returned}'"
+      end
     end
-  end
 
-  it "returns 'Unknown option' error message on options that are unknown" do
-    [
-      "noatime,unknownparam",
-      "mountvers2",
-      "nolock, bg",
-      "nolock,unknownoption",
-      "nolock,unknownassignment=true",
-      "nolock,two=equal=signs"
-    ].each do |options|
-      returned = Yast::NfsOptions.validate(options)
-      expect(returned).to start_with("Unknown option"), "options '#{options}' returned '#{returned}'"
+    it "returns 'Invalid option' error message on options that expect key=value and the value contains '='" do
+      [
+        "noatime,port=dort=fort",
+        "mountvers=port=23",
+        "nolock,retrans=trans=trans"
+      ].each do |options|
+        returned = Yast::NfsOptions.validate(options)
+        expect(returned).to start_with("Invalid option"), "options '#{options}' returned '#{returned}'"
+      end
+    end
+
+    it "returns 'Unknown option' error message on options that are unknown" do
+      [
+        "noatime,unknownparam",
+        "mountvers2",
+        "nolock, bg",
+        "nolock,unknownoption",
+        "nolock,unknownassignment=true",
+        "nolock,two=equal=signs"
+      ].each do |options|
+        returned = Yast::NfsOptions.validate(options)
+        expect(returned).to start_with("Unknown option"), "options '#{options}' returned '#{returned}'"
+      end
     end
   end
 end

--- a/test/nfs_test.rb
+++ b/test/nfs_test.rb
@@ -25,7 +25,7 @@ Yast.import "Nfs"
 Yast.import "Progress"
 Yast.import "Service"
 
-describe Yast::Nfs do
+describe "Yast::Nfs" do
   subject { Yast::Nfs }
 
   describe ".WriteOnly" do

--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -21,15 +21,15 @@ SRC_PATH = File.expand_path("../../src", __FILE__)
 DATA_PATH = File.join(File.expand_path(File.dirname(__FILE__)), "data")
 ENV["Y2DIR"] = SRC_PATH
 
+# make sure we run the tests in English locale
+# (some tests check the output which is marked for translation)
+ENV["LC_ALL"] = "en_US.UTF-8"
+
 require "yast"
 require "yast/rspec"
 
 if ENV["COVERAGE"]
   require "simplecov"
-  SimpleCov.start
-
-  # for coverage we need to load all ruby files
-  Dir["#{SRC_PATH}/lib/**/*.rb"].each { |f| require_relative f }
 
   # use coveralls for on-line code coverage reporting at Travis CI
   if ENV["TRAVIS"]
@@ -38,5 +38,13 @@ if ENV["COVERAGE"]
       SimpleCov::Formatter::HTMLFormatter,
       Coveralls::SimpleCov::Formatter
     ]
+  end
+
+  # track all ruby files under src
+  src_location = File.expand_path("../../src", __FILE__)
+  SimpleCov.track_files("#{src_location}/**/*.rb")
+
+  SimpleCov.start do
+    add_filter "/test/"
   end
 end

--- a/test/ui_test.rb
+++ b/test/ui_test.rb
@@ -1,0 +1,61 @@
+require_relative "spec_helper"
+
+module Yast
+  # just a wrapper class for the nfs/ui.rb
+  class NfsUiIncludeTesterClass < Module
+    extend Yast::I18n
+
+    def main
+      Yast.include self, "nfs/ui.rb"
+    end
+  end
+end
+
+NfsUiIncludeTester = Yast::NfsUiIncludeTesterClass.new
+NfsUiIncludeTester.main
+
+describe "Yast::NfsUiInclude" do
+  subject { NfsUiIncludeTester }
+  let(:server) { "nfs.suse.cz" }
+  let(:v4) { true }
+
+  describe "#scan_exports" do
+    before do
+      # mocks for the feedback popup
+      allow(Yast::UI).to receive(:OpenDialog).and_return(true)
+      allow(Yast::UI).to receive(:CloseDialog)
+      allow(Yast::UI).to receive(:WidgetExists).and_return(true)
+
+      allow(Yast::UI).to receive(:ChangeWidget)
+    end
+
+    context "scan fails" do
+      before do
+        expect(Yast::Nfs).to receive(:ProbeExports)
+      end
+
+      it "reports error when scan fails" do
+        expect(Yast::Report).to receive(:Error).with(/scan failed/)
+        subject.scan_exports(server, v4)
+      end
+    end
+
+    context "scan succeeds" do
+      let(:export) { "/export" }
+      before do
+        expect(Yast::Nfs).to receive(:ProbeExports).and_return([export])
+      end
+
+      it "displays a dialog for selecting the export" do
+        expect(subject).to receive(:ChooseExport).and_return(export)
+        subject.scan_exports(server, v4)
+      end
+
+      it "sets the selected export in the add dialog" do
+        allow(subject).to receive(:ChooseExport).and_return(export)
+        expect(Yast::UI).to receive(:ChangeWidget).with(Id(:pathent), :Value, export)
+        subject.scan_exports(server, v4)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- See https://bugzilla.suse.com/show_bug.cgi?id=1079624
- 4.0.2

### Notes

- Ignore the reported code coverage drop, the previous coverage was not counted properly
  (the client files were ignored)
- In reality the code coverage has been increased from 11% to 18%

## Screenshots

### Original Problem

Originally the module wanted to install a package when running in the inst-sys:

![nfs_package_installation](https://user-images.githubusercontent.com/907998/36604683-adda8b3a-18be-11e8-9620-25ae08f2de81.png)

Even canceling that resulted in `internal error` value offered to the user (uh, why? :open_mouth:):

![nfs_internal_error](https://user-images.githubusercontent.com/907998/36604705-c7b9e956-18be-11e8-8279-648e6459141d.png)

### Fix

The failed scan is now properly reported in a popup without that strange value offered to the user:

![nfs_scan_failed](https://user-images.githubusercontent.com/907998/36604793-056c474e-18bf-11e8-9d60-17406ed1e40d.png)

Moreover installing the package is not required and the scan works as expected:

![nfs_scan_fixed](https://user-images.githubusercontent.com/907998/36604828-1eee836c-18bf-11e8-9500-731d34c53516.png)
