### PR TITLE
Don't use nonexisting programs

### DIFF
--- a/package/yast2-nfs-client.changes
+++ b/package/yast2-nfs-client.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Feb 27 12:04:37 UTC 2019 - mvidner@suse.com
+
+- Use /sbin/rpcinfo only, /usr/sbin/rpcinfo is gone (bsc#1127138).
+- 4.1.5
+
+-------------------------------------------------------------------
 Fri Dec 28 11:54:27 CET 2018 - schubi@suse.de
 
 - Handle NFS version 4.2 (bsc#1118779).

--- a/package/yast2-nfs-client.spec
+++ b/package/yast2-nfs-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-nfs-client
-Version:        4.1.4
+Version:        4.1.5
 Release:        0
 Url:            https://github.com/yast/yast-nfs-client
 

--- a/src/modules/Nfs.rb
+++ b/src/modules/Nfs.rb
@@ -553,20 +553,10 @@ module Yast
     # Uses RPC broadcast to mountd.
     # @return [Array<String>] a list of hostnames
     def ProbeServers
-      # newer, shinier, better rpcinfo from rpcbind (#450056)
-      prog_name = "/sbin/rpcinfo"
-      delim = ""
-
-      # fallback from glibc (uses different field separators, grr :( )
-      # TODO: looks like glibc no longer contain this fallback?
-      if !FileUtils.Exists(prog_name)
-        prog_name = "/usr/sbin/rpcinfo"
-        delim = "-d ' ' "
-      end
-
       # #71064
       # this works also if ICMP broadcasts are ignored
-      cmd = "#{prog_name} -b mountd 1 | /usr/bin/cut #{delim} -f 2 | /usr/bin/sort -u"
+      # newer, shinier, better rpcinfo from rpcbind (#450056)
+      cmd = "/sbin/rpcinfo -b mountd 1 | /usr/bin/cut -f 2 | /usr/bin/sort -u"
       out = Convert.to_map(SCR.Execute(path(".target.bash_output"), cmd))
       Ops.get_string(out, "stdout", "").lines.map(&:strip).reject(&:empty?)
     end


### PR DESCRIPTION
/usr/sbin/rpcinfo does not exist, /sbin/rpcinfo is the only alternative

-   https://bugzilla.suse.com/show_bug.cgi?id=1127138
-   https://trello.com/c/plarcsbX/770-1-sle15-sp1-no-mkdir-is-not-in-usr-sbin
