### PR TITLE
Remove nfsidmap dependency (bsc#1153568)

### DIFF
--- a/package/yast2-nfs-client.changes
+++ b/package/yast2-nfs-client.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Oct 30 08:31:58 UTC 2019 - Knut Anderssen <kanderssen@suse.com>
+
+- Removed nfsidmap hardcoded dependency once libnfsidmap was merged
+  into nfs-utils and a separate package should not be needed
+  anymore (bsc#1150807, bsc#1153568)
+- 4.2.3
+
+-------------------------------------------------------------------
 Tue Aug 27 18:17:47 CEST 2019 - schubi@suse.de
 
 - Set X-SuSE-YaST-AutoInstResource in desktop file (bsc#144894).

--- a/package/yast2-nfs-client.spec
+++ b/package/yast2-nfs-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-nfs-client
-Version:        4.2.2
+Version:        4.2.3
 Release:        0
 Url:            https://github.com/yast/yast-nfs-client
 Summary:        YaST2 - NFS Configuration

--- a/src/modules/Nfs.rb
+++ b/src/modules/Nfs.rb
@@ -708,9 +708,6 @@ module Yast
         @required_packages = Builtins.add(@required_packages, "rpcbind")
         @portmapper = "rpcbind"
       end
-      if @nfs4_enabled
-        @required_packages = Builtins.add(@required_packages, "nfsidmap")
-      end
 
       if Mode.installation
         Builtins.foreach(@required_packages) do |p|


### PR DESCRIPTION
The package was dropped in TW

- https://bugzilla.suse.com/show_bug.cgi?id=1153568

Removed nfsidmap hardcoded dependency once libnfsidmap was merged into nfs-utils and a separate package should not be needed anymore (see [bsc#1150807#c3](https://bugzilla.suse.com/show_bug.cgi?id=1150807#c3) for further details)

