### PR TITLE
Refresh the UI after sync NFS entries from storage

### DIFF
--- a/package/yast2-nfs-client.changes
+++ b/package/yast2-nfs-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jan  8 22:49:11 UTC 2020 - David Diaz <dgonzalez@suse.com>
+
+- Avoids displaying phantom NFS entries adding an action to
+  refresh the UI (related to bsc#1156446).
+- 4.1.6
+
+-------------------------------------------------------------------
 Wed Feb 27 12:04:37 UTC 2019 - mvidner@suse.com
 
 - Use /sbin/rpcinfo only, /usr/sbin/rpcinfo is gone (bsc#1127138).

--- a/package/yast2-nfs-client.spec
+++ b/package/yast2-nfs-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-nfs-client
-Version:        4.1.5
+Version:        4.1.6
 Release:        0
 Url:            https://github.com/yast/yast-nfs-client
 

--- a/src/clients/nfs-client4part.rb
+++ b/src/clients/nfs-client4part.rb
@@ -32,6 +32,8 @@ module Yast
 
       if @func == "CreateUI"
         return create_ui
+      elsif @func == "RefreshUI"
+        return refresh_ui
       elsif @func == "FromStorage"
         shares = Ops.get_list(@param, "shares", [])
         @nfs_entries = Nfs.load_nfs_entries(shares)
@@ -54,7 +56,7 @@ module Yast
       nil
     end
 
-    private
+  private
 
     # Generates the UI that allows to manage the NFS shares entries
     #
@@ -62,10 +64,14 @@ module Yast
     def create_ui
       Wizard.SetHelpText(@help_text1)
 
-      ReplacePoint(
-        id,
-        FstabTab()
-      )
+      ReplacePoint(id, FstabTab())
+    end
+
+    # Updates the UI that allows to manage the NFS shares entries
+    #
+    # @return [Boolean] true when entries are successfully replaced; false otherwise.
+    def refresh_ui
+      UI.ReplaceWidget(id, FstabTab())
     end
 
     # Returns the id for the NFS shares UI replace point

--- a/src/clients/nfs-client4part.rb
+++ b/src/clients/nfs-client4part.rb
@@ -31,8 +31,7 @@ module Yast
       end
 
       if @func == "CreateUI"
-        Wizard.SetHelpText(@help_text1)
-        return FstabTab()
+        return create_ui
       elsif @func == "FromStorage"
         shares = Ops.get_list(@param, "shares", [])
         @nfs_entries = Nfs.load_nfs_entries(shares)
@@ -53,6 +52,25 @@ module Yast
       end
 
       nil
+    end
+
+    private
+
+    # Generates the UI that allows to manage the NFS shares entries
+    #
+    # @return [Yast::Term] a term defining the UI
+    def create_ui
+      Wizard.SetHelpText(@help_text1)
+
+      ReplacePoint(
+        id,
+        FstabTab()
+      )
+    end
+
+    # Returns the id for the NFS shares UI replace point
+    def id
+      @id ||= Id(:fstab_rp)
     end
   end
 end

--- a/src/clients/nfs-client4part.rb
+++ b/src/clients/nfs-client4part.rb
@@ -30,17 +30,18 @@ module Yast
         end
       end
 
-      if @func == "CreateUI"
+      case @func
+      when "CreateUI"
         return create_ui
-      elsif @func == "RefreshUI"
+      when "RefreshUI"
         return refresh_ui
-      elsif @func == "FromStorage"
-        shares = Ops.get_list(@param, "shares", [])
+      when "FromStorage"
+        shares = @param.fetch("shares", [])
         @nfs_entries = Nfs.load_nfs_entries(shares)
-      elsif @func == "Read"
+      when "Read"
         Nfs.skip_fstab = true
         Nfs.Read
-      elsif @func == "HandleEvent"
+      when "HandleEvent"
         @widget_id = Ops.get(@param, "widget_id")
         @w_ids = [:newbut, :editbut, :delbut]
 

--- a/src/clients/nfs-client4part.rb
+++ b/src/clients/nfs-client4part.rb
@@ -33,11 +33,10 @@ module Yast
       case @func
       when "CreateUI"
         return create_ui
-      when "RefreshUI"
-        return refresh_ui
       when "FromStorage"
         shares = @param.fetch("shares", [])
         @nfs_entries = Nfs.load_nfs_entries(shares)
+        refresh_ui
       when "Read"
         Nfs.skip_fstab = true
         Nfs.Read
@@ -72,6 +71,10 @@ module Yast
     #
     # @return [Boolean] true when entries are successfully replaced; false otherwise.
     def refresh_ui
+      # The UI could be not available yet as FromStorage action can be called just to sync
+      # the NFS entries before create the interface.
+      return unless UI.WidgetExists(ui_id)
+
       UI.ReplaceWidget(ui_id, FstabTab())
     end
 

--- a/src/clients/nfs-client4part.rb
+++ b/src/clients/nfs-client4part.rb
@@ -65,19 +65,19 @@ module Yast
     def create_ui
       Wizard.SetHelpText(@help_text1)
 
-      ReplacePoint(id, FstabTab())
+      ReplacePoint(ui_id, FstabTab())
     end
 
     # Updates the UI that allows to manage the NFS shares entries
     #
     # @return [Boolean] true when entries are successfully replaced; false otherwise.
     def refresh_ui
-      UI.ReplaceWidget(id, FstabTab())
+      UI.ReplaceWidget(ui_id, FstabTab())
     end
 
     # Returns the id for the NFS shares UI replace point
-    def id
-      @id ||= Id(:fstab_rp)
+    def ui_id
+      @ui_id ||= Id(:fstab_rp)
     end
   end
 end


### PR DESCRIPTION
## Problem

When running the [`NfsClient4partClient`](https://github.com/yast/yast-nfs-client/blob/SLE-15-SP1/src/clients/nfs-client4part.rb) from [`yast-storage-ng`](https://github.com/yast/yast-storage-ng/blob/SLE-15-SP1/src/lib/y2partitioner/yast_nfs_client.rb), the user can discard a not reachable NFS entry just after creating it. However, However, [changes done in the UI](https://github.com/yast/yast-nfs-client/blob/23eb048f5f52629d0e5fba2e7c9e773c0fa1d469/src/include/nfs/ui.rb#L593) are not reverted, which could end with a crash if the user tries to edit that phantom entry (maybe to _fix_ it).

![nfs-bug-explained](https://user-images.githubusercontent.com/1691872/72056311-4c1a6b00-32c4-11ea-90d0-af1b2d77d487.png)



* Bugzilla: https://bugzilla.suse.com/show_bug.cgi?id=1156446
* Trello: https://trello.com/c/WGmxRkxu

## Proposed solution

To wrap the involved piece of UI in a `ReplacePoint` and ~~provide an action to refresh it, which can be called after update the entries via~~<sup>1</sup> refresh it after call to [_FromStorage_](https://github.com/yast/yast-nfs-client/blob/23eb048f5f52629d0e5fba2e7c9e773c0fa1d469/src/clients/nfs-client4part.rb#L36).

## Tests

Tested only manually since there are no unit tests for that client and this fix is a workaround in which we don't want to invest too much time there is another PBI to improve the integration between `yast-storage-ng` and `yast-nfs-client` (see https://trello.com/c/RLlMWgGd)

## Notes

I added those tiny private methods directly in the client to not continue increasing the [NfsUIInclude](https://github.com/yast/yast-nfs-client/blob/SLE-15-SP1/src/include/nfs/ui.rb) module. As a _side effect_, I also had to change the `if/elsif` by a `case` statement to make Rubocop happy and not complaining about _ Use a guard clause instead of wrapping the code inside a conditional expression_. Anyway, I also prefer the `case` over the `if...elsif...elsif...else` here.

---

<sup>1</sup> Original implementation provided a "RefreshUI" action which was removed in https://github.com/yast/yast-nfs-client/pull/87/commits/ec9bb889bf73c0c91024f6b696ab3de208f40d62 due to https://github.com/yast/yast-storage-ng/pull/1018#discussion_r364660436 
