### PR TITLE
[SLE-15-SP2/master] Refresh the UI after sync NFS entries from storage

### DIFF
--- a/package/yast2-nfs-client.changes
+++ b/package/yast2-nfs-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jan  8 22:49:11 UTC 2020 - David Diaz <dgonzalez@suse.com>
+
+- Avoids displaying phantom NFS entries adding an action to
+  refresh the UI (related to bsc#1156446).
+- 4.2.4
+
+-------------------------------------------------------------------
 Wed Oct 30 08:31:58 UTC 2019 - Knut Anderssen <kanderssen@suse.com>
 
 - Removed nfsidmap hardcoded dependency once libnfsidmap was merged

--- a/package/yast2-nfs-client.spec
+++ b/package/yast2-nfs-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-nfs-client
-Version:        4.2.3
+Version:        4.2.4
 Release:        0
 Url:            https://github.com/yast/yast-nfs-client
 Summary:        YaST2 - NFS Configuration


### PR DESCRIPTION
>  :memo: The same than #87, but for `master` (aka `SLE-15-SP2`)

---

Refresh the UI when _FromStorage_ action is called. See the [original PR](https://github.com/yast/yast-nfs-client/pull/87) for more details.