### PR TITLE
Improve behavior for standalone client

### DIFF
--- a/package/yast2-nfs-client.changes
+++ b/package/yast2-nfs-client.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Fri Jan 17 12:49:20 UTC 2020 - José Iván López González <jlopez@suse.com>
+
+- Delegates mount/unmount actions to yast2-storage-ng.
+- Keeps mount point status for existing shares.
+- Adds an asterisk to mount point for unmounted entries.
+- Related to bsc#1006815, bsc#1151426, bsc#1060159.
+- 4.1.7
+
+-------------------------------------------------------------------
 Wed Jan  8 22:49:11 UTC 2020 - David Diaz <dgonzalez@suse.com>
 
 - Avoids displaying phantom NFS entries adding an action to

--- a/package/yast2-nfs-client.spec
+++ b/package/yast2-nfs-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-nfs-client
-Version:        4.1.6
+Version:        4.1.7
 Release:        0
 Url:            https://github.com/yast/yast-nfs-client
 

--- a/package/yast2-nfs-client.spec
+++ b/package/yast2-nfs-client.spec
@@ -41,10 +41,10 @@ Requires:       yast2 >= 4.0.39
 Requires:       yast2-nfs-common >= 2.24.0
 # showmount, #150382, #286300
 Recommends:     nfs-client
-# Y2Storage::MountPoint#active=
-Requires:       yast2-storage-ng >= 4.0.180
-# Y2Storage::MountPoint#active=
-BuildRequires:  yast2-storage-ng >= 4.0.180
+# Y2Storage::Filesystems::LegacyNfs#configure_from
+Requires:       yast2-storage-ng >= 4.1.91
+# Y2Storage::Filesystems::LegacyNfs#configure_from
+BuildRequires:  yast2-storage-ng >= 4.1.91
 
 # Unfortunately we cannot move this to macros.yast,
 # bcond within macros are ignored by osc/OBS.

--- a/src/include/nfs/routines.rb
+++ b/src/include/nfs/routines.rb
@@ -1,4 +1,21 @@
-# encoding: utf-8
+# Copyright (c) [2013-2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
 
 require "y2nfs_client/nfs_version"
 require "y2storage"
@@ -233,6 +250,18 @@ module Yast
       }
     end
 
+    # Creates a LegacyNfs object according to the given entry
+    #
+    # @param entry [Hash] NFS mount in the .etc.fstab format that uses keys such as "spec", "file", etc.
+    # @return [Y2Storage::Filesystems::LegacyNfs]
+    def to_legacy_nfs(entry)
+      storage_hash = fstab_to_storage(entry)
+      legacy = Y2Storage::Filesystems::LegacyNfs.new_from_hash(storage_hash)
+      legacy.default_devicegraph = working_graph
+
+      legacy
+    end
+
   private
 
     # @see #FstabTableItems
@@ -264,6 +293,13 @@ module Yast
     # @return [Y2Storage::Devicegraph]
     def working_graph
       storage_manager.staging
+    end
+
+    # Devicegraph representing the current system status
+    #
+    # @return [Y2Storage::Devicegraph]
+    def system_graph
+      storage_manager.probed
     end
 
     # Mount points present on /etc/fstab but not handled by the yast-nfs-client

--- a/src/include/nfs/ui.rb
+++ b/src/include/nfs/ui.rb
@@ -1,4 +1,22 @@
-# encoding: utf-8
+# Copyright (c) [2013-2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
 require "y2firewall/firewalld"
 require "yast2/feedback"
 require "yast2/popup"
@@ -219,6 +237,8 @@ module Yast
       ret = nil
 
       if fstab_ent
+        new_entry = fstab_ent.fetch("new", false)
+
         couple = SpecToServPath(Ops.get_string(fstab_ent, "spec", ""))
         server = Ops.get_string(couple, 0, "")
         pth = Ops.get_string(couple, 1, "")
@@ -227,6 +247,8 @@ module Yast
         servers = [server]
         old = Ops.get_string(fstab_ent, "spec", "")
       else
+        new_entry = true
+
         proposed_server = ProposeHostname()
         servers = [proposed_server] if HostnameExists(proposed_server)
       end
@@ -449,6 +471,11 @@ module Yast
 
       UI.CloseDialog
       Wizard.RestoreScreenShotName
+
+      # New entries are identify by "new" key in the hash. This is useful to detect which entries are
+      # not created but updated. Note that this is important to keep the current mount point status of
+      # updated entries.
+      fstab_ent["new"] = new_entry
 
       return deep_copy(fstab_ent) if ret == :ok
       nil

--- a/src/include/nfs/ui.rb
+++ b/src/include/nfs/ui.rb
@@ -69,9 +69,12 @@ module Yast
         # Help, part 2 of 4
         _(
           "<p>Each NFS share is identified by remote NFS server address and\n" \
-            "exported directory, local directory where the remote directory is mounted, \n" \
-            "version of the NFS protocol and mount options. For further information \n" \
-            "about mounting NFS and mount options, refer to <tt>man nfs.</tt></p>"
+          "exported directory, local directory where the remote directory is mounted, \n" \
+          "version of the NFS protocol and mount options. For further information \n" \
+          "about mounting NFS and mount options, refer to <tt>man nfs</tt>.</p>\n" \
+          "<p>An asterisk (*) after the mount point indicates a file system that is \n" \
+          "currently not mounted (for example, because it has the <tt>noauto</tt> \n" \
+          "option set in <tt>/etc/fstab</tt>).</p>"
         ) +
         # Help, part 3 of 4
         _(

--- a/test/ui_test.rb
+++ b/test/ui_test.rb
@@ -1,4 +1,24 @@
-#! /usr/bin/env rspec
+#!/usr/bin/env rspec
+
+# Copyright (c) [2018-2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com
+
 require_relative "spec_helper"
 
 module Yast


### PR DESCRIPTION
NOTE FOR REVIEWERS: unit tests are failing because they required an updated docker image, which is being built.

### Problem

The NFS client behaves in a different way when it woks standalone and inside the Expert Partitioner.

The Partitioner version was already adapted to fix some issues, see https://github.com/yast/yast-storage-ng/pull/1021.

Now, the standalone NFS client needs to be improved to behave exactly as the Partitioner when a new entry is added, edited or deleted. 

Part of PBI: https://trello.com/c/Z8gqtcC1/1484-3-nfs-client-and-unmounting-bug1006815-bug1151426

Related bugs:

* https://bugzilla.suse.com/show_bug.cgi?id=1006815
* https://bugzilla.suse.com/show_bug.cgi?id=1151426
* https://bugzilla.suse.com/show_bug.cgi?id=1060159 

### Solution

The client was adapted to keep mount point status when an existing entry is edited. This implies that the NFS share will be mounted only if it was mounted previously. And it will be written to the fstab file if it was already in the fstab.

Moreover, unmounted entries are now marked with an asterisk in their mount point (similar to the Expert Partitioner).

Requires this changes in yast2-storage-ng: https://github.com/yast/yast-storage-ng/pull/1021.

### Testing

* Manually tested
* Added unit tests.
