### PR TITLE
Fix rpcbind activation

### DIFF
--- a/package/yast2-nfs-client.changes
+++ b/package/yast2-nfs-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Feb  6 15:29:51 UTC 2020 - José Iván López González <jlopez@suse.com>
+
+- Kill rpcbind process if it was directly executed without using
+  systemd (bsc#1161687).
+- 4.1.8
+
+-------------------------------------------------------------------
 Fri Jan 17 12:49:20 UTC 2020 - José Iván López González <jlopez@suse.com>
 
 - Delegates mount/unmount actions to yast2-storage-ng.

--- a/package/yast2-nfs-client.spec
+++ b/package/yast2-nfs-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-nfs-client
-Version:        4.1.7
+Version:        4.1.8
 Release:        0
 Url:            https://github.com/yast/yast-nfs-client
 

--- a/package/yast2-nfs-client.spec
+++ b/package/yast2-nfs-client.spec
@@ -28,15 +28,15 @@ BuildRequires:  perl-XML-Writer
 BuildRequires:  update-desktop-files
 BuildRequires:  yast2-devtools >= 3.1.27
 BuildRequires:  yast2-testsuite
-# SuSEFirewall2 replaced by firewalld (fate#323460)
-BuildRequires:  yast2 >= 4.0.39
+# Yast::Execute.locally
+BuildRequires:  yast2 >= 4.1.42
 BuildRequires:  rubygem(rspec)
 #for install task
 BuildRequires:  rubygem(%rb_default_ruby_abi:yast-rake)
 # path_matching (RSpec argument matcher)
 BuildRequires:  yast2-ruby-bindings >= 3.1.31
-# SuSEFirewall2 replaced by firewalld (fate#323460)
-Requires:       yast2 >= 4.0.39
+# Yast::Execute.locally
+BuildRequires:  yast2 >= 4.1.42
 #idmapd_conf agent
 Requires:       yast2-nfs-common >= 2.24.0
 # showmount, #150382, #286300


### PR DESCRIPTION
## Problem

After mounting NFS shares, the *rpcbind* service is started if it is not currently active. But, just before mounting NFS shares, *libstorage-ng* runs *rpcbind* binary directly without using systemd. So, from the systemd point of view, the service is inactive even though the *rpcbind* process is running. This makes systemd to fail when trying to start *rpcbind* service.

This problem was introduced after delegating NFS mounting to *libstorage-ng*, see https://github.com/yast/yast-nfs-client/pull/89.

* https://bugzilla.suse.com/show_bug.cgi?id=1161687

## Solution

Try to kill *rpcbind* process before activating the service.

## Testing

* Added unit tests.
* Manually tested.
