### PR TITLE
Fix Crash when using [Cancel] in the "Add" Dialog

### DIFF
--- a/package/yast2-nfs-client.changes
+++ b/package/yast2-nfs-client.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon May 11 15:04:25 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Fixed crash when using [Cancel] in the "Add" dialog (bsc#1170447)
+- 4.2.8
+
+-------------------------------------------------------------------
 Thu Feb  6 15:29:51 UTC 2020 - José Iván López González <jlopez@suse.com>
 
 - Kill rpcbind process if it was directly executed without using

--- a/package/yast2-nfs-client.spec
+++ b/package/yast2-nfs-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-nfs-client
-Version:        4.2.7
+Version:        4.2.8
 Release:        0
 Url:            https://github.com/yast/yast-nfs-client
 Summary:        YaST2 - NFS Configuration

--- a/src/include/nfs/ui.rb
+++ b/src/include/nfs/ui.rb
@@ -475,6 +475,8 @@ module Yast
       UI.CloseDialog
       Wizard.RestoreScreenShotName
 
+      return nil if ret == :cancel
+
       # New entries are identify by "new" key in the hash. This is useful to detect which entries are
       # not created but updated. Note that this is important to keep the current mount point status of
       # updated entries.


### PR DESCRIPTION
## Trello

https://trello.com/c/pFojD78b/

## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1170447

## Problem

Crash when hitting the [Cancel] button in the "Add" dialog in the YaST NFS client module.

## Fix

Don't try to operate on nonexistent values, return with `nil` instead.