### PR TITLE
Fix Crash when using [Cancel] in the "Add" Dialog

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM registry.opensuse.org/yast/sle-15/sp2/containers/yast-ruby
+FROM registry.opensuse.org/yast/head/containers/yast-ruby:latest
 COPY . /usr/src/app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM registry.opensuse.org/yast/head/containers/yast-ruby:latest
+FROM registry.opensuse.org/yast/sle-15/sp2/containers/yast-ruby
 COPY . /usr/src/app
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,5 @@
 require "yast/rake"
 
-Yast::Tasks.submit_to :sle15sp2
-
 Yast::Tasks.configuration do |conf|
   # lets ignore license check for now
   conf.skip_license_check << /.*/

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,7 @@
 require "yast/rake"
 
+Yast::Tasks.submit_to :sle15sp2
+
 Yast::Tasks.configuration do |conf|
   # lets ignore license check for now
   conf.skip_license_check << /.*/

--- a/package/yast2-nfs-client.changes
+++ b/package/yast2-nfs-client.changes
@@ -2,7 +2,7 @@
 Mon May 11 15:04:25 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Fixed crash when using [Cancel] in the "Add" dialog (bsc#1170447)
-- 4.2.8
+- 4.3.0
 
 -------------------------------------------------------------------
 Thu Feb  6 15:29:51 UTC 2020 - José Iván López González <jlopez@suse.com>

--- a/package/yast2-nfs-client.spec
+++ b/package/yast2-nfs-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-nfs-client
-Version:        4.2.8
+Version:        4.3.0
 Release:        0
 Url:            https://github.com/yast/yast-nfs-client
 Summary:        YaST2 - NFS Configuration


### PR DESCRIPTION
_This merges PR #95 into master_

## Trello

https://trello.com/c/pFojD78b/

## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1170447

## Problem

Crash when hitting the [Cancel] button in the "Add" dialog in the YaST NFS client module.

## Fix

Don't try to operate on nonexistent values, return with `nil` instead.

## Test

Manual test in a VM.

## Other Problems

This code is full of YCP zombies: Lots of `Builtins.add()` and `Builtins.whatever()` all over the place. They should really be cleaned up.

But I wanted to keep the diff minimal for this since we need to release this as a maintenance update.


## Related PR

https://github.com/yast/yast-nfs-client/pull/95