### PR TITLE
Schema change

### DIFF
--- a/package/yast2-nfs-client.changes
+++ b/package/yast2-nfs-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue May 12 13:41:33 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
+
+- Autoyast schema: Allow optional types for string and map objects
+  (bsc#1170886)
+- 4.3.1
+
+-------------------------------------------------------------------
 Mon May 11 15:04:25 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Fixed crash when using [Cancel] in the "Add" dialog (bsc#1170447)

--- a/package/yast2-nfs-client.spec
+++ b/package/yast2-nfs-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-nfs-client
-Version:        4.3.0
+Version:        4.3.1
 Release:        0
 Url:            https://github.com/yast/yast-nfs-client
 Summary:        YaST2 - NFS Configuration

--- a/src/autoyast-rnc/nfs.rnc
+++ b/src/autoyast-rnc/nfs.rnc
@@ -1,5 +1,7 @@
 # It is complicated.
 
+include "common.rnc"
+
 nfs_entry_content = (
       element server_path { text }
     & element mount_point { text }
@@ -10,10 +12,11 @@ nfs_entry_content = (
 # SLE11-SP2 and earlier, openSUSE 11.2 and earlier:
 # A list of entries
 # (This definition is unused below but provided for historical context)
-nfs_sle11_sp2 = 
+nfs_sle11_sp2 =
   element nfs {
     LIST,
     element nfs_entry {
+        MAP,
         nfs_entry_content
     }*
   }
@@ -29,13 +32,17 @@ nfs_global_options_content = (
 
 nfs_os113_123 =
   element nfs {
-    nfs_global_options_content,
-    element nfs_entries {
-      LIST,
-      element nfs_entry {
-        nfs_entry_content
-      }*
-    }
+    MAP,
+    (
+      nfs_global_options_content,
+      element nfs_entries {
+        LIST,
+        element nfs_entry {
+          MAP,
+          nfs_entry_content
+        }*
+      }
+    )
   }
 
 # Now we want to port the options to SLE11-SP3.
@@ -49,9 +56,11 @@ nfs_sle11_sp3 =
   element nfs {
     LIST,
     element nfs_entry {
+        MAP,
         nfs_global_options_content
     }? ,
     element nfs_entry {
+        MAP,
         nfs_entry_content
     }*
   }


### PR DESCRIPTION
trello: https://trello.com/c/HkFkUQHj/1791-3-continue-with-new-xml-parser-xml-validation

depends on yast/yast-autoinstallation#598

Agreed to postpone for now that trang and jing travis validation to not delay even more new xml parser.

bsc: https://bugzilla.suse.com/show_bug.cgi?id=1170886