### PR TITLE
Popup fix

### DIFF
--- a/package/yast2-nfs-client.changes
+++ b/package/yast2-nfs-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Feb 18 15:16:03 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
+
+- Adapted unit test to recent changes in Yast::Report (related to
+  bsc#1179893).
+- 4.3.3
+
+-------------------------------------------------------------------
 Mon Aug 10 17:10:07 CEST 2020 - schubi@suse.de
 
 - AutoYaST: Added supplements: autoyast(nfs) into the spec file

--- a/package/yast2-nfs-client.spec
+++ b/package/yast2-nfs-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-nfs-client
-Version:        4.3.2
+Version:        4.3.3
 Release:        0
 Url:            https://github.com/yast/yast-nfs-client
 Summary:        YaST2 - NFS Configuration

--- a/test/nfs_test.rb
+++ b/test/nfs_test.rb
@@ -64,7 +64,7 @@ describe "Yast::Nfs" do
     allow(sm).to receive(:probe).and_return true
 
     # prevent storage-commit
-    allow(sm).to receive(:commit)
+    allow(sm).to receive(:commit).and_return(true)
   end
 
   subject { Yast::Nfs }
@@ -258,7 +258,7 @@ describe "Yast::Nfs" do
       allow(Yast::Progress).to receive(:set)
       allow(Yast::Service).to receive(:Enable)
       allow(Yast::SCR).to receive(:Execute)
-        .with(path(".target.mkdir"), anything)
+        .with(path(".target.mkdir"), anything).and_return(true)
       allow(Yast::SCR).to receive(:Write)
         .with(path_matching(/^\.sysconfig\.nfs/), any_args)
       allow(Yast::SCR).to receive(:Write)
@@ -461,7 +461,7 @@ describe "Yast::Nfs" do
       allow(Yast::Progress).to receive(:set)
       allow(Yast::Service).to receive(:Start)
       allow(Yast::Service).to receive(:Stop)
-      allow(Yast::Service).to receive(:active?)
+      allow(Yast::Service).to receive(:active?).and_return(true)
       allow(Yast::Execute).to receive(:locally).and_return(execute_object)
 
       allow_read_side_effects
@@ -485,9 +485,9 @@ describe "Yast::Nfs" do
           .and_return(service_status1, service_status2)
       end
 
-      let(:service_status1) { nil }
+      let(:service_status1) { true }
 
-      let(:service_status2) { nil }
+      let(:service_status2) { true }
 
       context "and the portmapper service is not active" do
         let(:service_status1) { false }
@@ -514,6 +514,10 @@ describe "Yast::Nfs" do
 
         context "and the portmapper service was not activated" do
           let(:service_status2) { false }
+
+          before do
+            allow(Yast::Report).to receive(:Error)
+          end
 
           it "reports an error" do
             expect(Yast::Report).to receive(:Error).with(/Cannot start/)

--- a/test/routines_test.rb
+++ b/test/routines_test.rb
@@ -293,6 +293,10 @@ describe "Yast::NfsRoutinesInclude" do
         end
       end
       context "and does not begin with a slash" do
+        before do
+          allow(Yast::Report).to receive(:Error)
+        end
+
         it "returns false" do
           expect(subject.CheckPath(path.to_s)).to eq(false)
         end
@@ -304,10 +308,15 @@ describe "Yast::NfsRoutinesInclude" do
       end
     end
     context "when the given path size is out of the 1..69 range" do
+      before do
+        allow(Yast::Report).to receive(:Error)
+      end
+
       it "reports and error" do
         expect(Yast::Report).to receive(:Error).with(/The path entered is invalid/)
         subject.CheckPath("/#{path}/verylong")
       end
+
       it "returns false" do
         expect(subject.CheckPath("/#{path}/verylong")).to eq(false)
       end


### PR DESCRIPTION
This pull request in yast-yast2 (https://github.com/yast/yast-yast2/pull/1122) changed the behavior during unit tests of `Yast::Report` and `Yast2::Popup`, making necessary to add some extra mocking to prevent YaST from trying to open windows during the test execution.

As far as we know, that affected the test-suites of: yast-storage-ng, yast-country, yast-firewall, yast-nfs-server, yast-nis-client, yast-pam, yast-security, yast-services-manager and yast-sysconfig.

This should fix the problem for this repository.