### PR TITLE
Adding psmisc to required_packages

### DIFF
--- a/package/yast2-nfs-client.changes
+++ b/package/yast2-nfs-client.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Dec 13 18:34:58 UTC 2021 - Georg Pfuetzenreuter <mail@georg-pfuetzenreuter.net>
+
+- Adding /usr/bin/killall as a requirement (bsc#1161687)
+- 4.4.2
+
+-------------------------------------------------------------------
 Tue Jun 29 09:43:08 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
 
 - Support systemd mount options in fstab (bsc#1187781)

--- a/package/yast2-nfs-client.spec
+++ b/package/yast2-nfs-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-nfs-client
-Version:        4.4.1
+Version:        4.4.2
 Release:        0
 Url:            https://github.com/yast/yast-nfs-client
 Summary:        YaST2 - NFS Configuration
@@ -55,6 +55,8 @@ Recommends:     nfs-client
 # Y2Storage::Filesystems::LegacyNfs#configure_from
 Requires:       yast2-storage-ng >= 4.2.73
 Requires:       yast2-ruby-bindings >= 1.0.0
+# bsc#1161687
+Requires:	/usr/bin/killall
 
 Provides:       yast2-config-nfs
 Provides:       yast2-config-nfs-devel

--- a/src/modules/Nfs.rb
+++ b/src/modules/Nfs.rb
@@ -55,7 +55,7 @@ module Yast
       @skip_fstab = false
 
       # Required packages
-      @required_packages = ["nfs-client", "psmisc"]
+      @required_packages = ["nfs-client"]
 
       # eg.: [ $["spec": "moon:/cheese", file: "/mooncheese", "mntops": "defaults"], ...]
       @nfs_entries = []

--- a/src/modules/Nfs.rb
+++ b/src/modules/Nfs.rb
@@ -55,7 +55,7 @@ module Yast
       @skip_fstab = false
 
       # Required packages
-      @required_packages = ["nfs-client"]
+      @required_packages = ["nfs-client", "psmisc"]
 
       # eg.: [ $["spec": "moon:/cheese", file: "/mooncheese", "mntops": "defaults"], ...]
       @nfs_entries = []


### PR DESCRIPTION
Hi,

I encountered an error about `killall` not being found upon adding an NFS share on a system without psmisc installed, since a recent update seems to have added a function to reload `rpcbind` using `killall`. Adding `psmisc` to `required_packages` should make for an easy solution for future deployments.

Since this is only adding a single string I did not ask before submitting this, but if there are any concerns, I am acidsys in #yast.

Thanks for the nice software!

Signed-off-by: Georg <georg@lysergic.dev>