### PR TITLE
Cache hosts

### DIFF
--- a/src/include/nfs/ui.rb
+++ b/src/include/nfs/ui.rb
@@ -47,7 +47,6 @@ module Yast
       Yast.include include_target, "nfs/routines.rb"
 
       # Caches names of nfs servers for GetFstabEntry
-
       @hosts = nil
 
       # List of already defined nfs mount points
@@ -124,7 +123,7 @@ module Yast
         nfs.fstopt = "defaults"
       end
 
-      form = Y2NfsClient::Widgets::NfsForm.new(nfs, nfs_entries)
+      form = Y2NfsClient::Widgets::NfsForm.new(nfs, nfs_entries, hosts: @hosts)
       return nil unless form.run?
 
       UI.OpenDialog(
@@ -166,6 +165,8 @@ module Yast
         end
         break if [:ok, :cancel].include?(ret)
       end
+
+      @hosts = form.hosts
 
       UI.CloseDialog
       Wizard.RestoreScreenShotName

--- a/src/lib/y2nfs_client/widgets/nfs_form.rb
+++ b/src/lib/y2nfs_client/widgets/nfs_form.rb
@@ -32,12 +32,19 @@ module Y2NfsClient
     class NfsForm < CWM::CustomWidget
       Yast.import "NfsOptions"
 
+      # List of cached hosts
+      #
+      # @return [Array<String>, nil]
+      attr_reader :hosts
+
       # Constructor
       #
       # @param nfs [Y2Storage::Filesystems::LegacyNfs] Object representing a nfs entry. This object is
       #   modified in #store method.
       # @param nfs_entries [Array<Y2Storage::Filesystems::LegacyNfs>] The rest of entries
-      def initialize(nfs, nfs_entries)
+      # @param hosts [Array<String>, nil] List of cached hosts. Passing a list avoids to perform a new
+      #   search.
+      def initialize(nfs, nfs_entries, hosts: nil)
         super()
 
         Yast.import "Nfs"
@@ -56,6 +63,7 @@ module Y2NfsClient
         @mount_options = nfs.fstopt || ""
 
         @nfs_entries = nfs_entries
+        @hosts = hosts
       end
 
       # NFS being created or edited
@@ -305,8 +313,8 @@ module Y2NfsClient
         Yast::UI.QueryWidget(Id(:optionsent), :Value).strip
       end
 
+      # FIXME: Hosts are not correctly found, see bsc#1167589
       def handle_choose
-        # FIXME: @hosts is supposed to be a cache for the whole module execution
         if @hosts.nil?
           # label message
           Yast::UI.OpenDialog(Label(_("Scanning for hosts on this LAN...")))


### PR DESCRIPTION
## Problem

The feature for caching hosts was lost after the chages to improve the integreation with the YaST Partitioner, see https://github.com/yast/yast-nfs-client/pull/105. This makes the YaST to recalcualate the list of hosts when the NFS form is left.

## Solution

Recover the hosts caching. Anyway, be aware that the hosts searching is not working as expected, but that is not fixed with this PR, see https://bugzilla.suse.com/show_bug.cgi?id=1167589.

## Testing

* Tested manually
* Added unit test [Todo]