### PR TITLE
Fixed unit test (bsc#1209007)

### DIFF
--- a/package/yast2-nfs-client.changes
+++ b/package/yast2-nfs-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Mar  7 12:27:28 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
+
+- Fixed unit test to not read the values from the current system
+  (bsc#1209007)
+- 4.5.2
+
+-------------------------------------------------------------------
 Wed May 11 13:12:14 UTC 2022 - Josef Reidinger <jreidinger@suse.com>
 
 - Fix localization of NFS Version widget values (bsc#1198076)

--- a/package/yast2-nfs-client.spec
+++ b/package/yast2-nfs-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-nfs-client
-Version:        4.5.1
+Version:        4.5.2
 Release:        0
 Url:            https://github.com/yast/yast-nfs-client
 Summary:        YaST2 - NFS Configuration

--- a/test/nfs_test.rb
+++ b/test/nfs_test.rb
@@ -52,6 +52,7 @@ describe "Yast::Nfs" do
     add_nfs_devices
 
     subject.skip_fstab = false
+    allow_read_side_effects
     subject.Read
   end
 


### PR DESCRIPTION
## Problem

- The unit test [failed in Jenkins](https://ci.suse.de/view/YaST/job/yast-yast-nfs-client-SLE-15-SP5/761/console):
```
[   14s]   1) Yast::Nfs .Export exports the current nfs settings as a map
[   14s]      Failure/Error: subject.Read
[   14s] 
[   14s]      RuntimeError:
[   14s]        Failed to find / at /proc/mounts
[   14s]      # /usr/share/YaST2/modules/Package.rb:449:in `IsTransactionalSystem'
[   14s]      # /usr/share/YaST2/modules/Package.rb:519:in `check_transactional_system!'
[   14s]      # /usr/share/YaST2/modules/Package.rb:323:in `PackageDialog'
[   14s]      # /usr/share/YaST2/modules/Package.rb:378:in `InstallAllMsg'
[   14s]      # /usr/share/YaST2/modules/Package.rb:412:in `InstallAll'
[   14s]      # /usr/share/YaST2/modules/Package.rb:152:in `CheckAndInstallPackages'
[   14s]      # /usr/share/YaST2/modules/Package.rb:165:in `CheckAndInstallPackagesInteractive'
[   14s]      # ./src/modules/Nfs.rb:681:in `check_and_install_required_packages'
[   14s]      # ./src/modules/Nfs.rb:298:in `Read'
[   14s]      # ./test/nfs_test.rb:55:in `mock_entries'
[   14s]      # ./test/nfs_test.rb:158:in `block (3 levels) in <top (required)>'
```
- When running locally as non-root I got this error:
```
  1) Yast::Nfs .Export exports the current nfs settings as a map
     Failure/Error: subject.Read
     
     RuntimeError:
       Failed to open dialog, see logs.
     # /usr/share/YaST2/lib/yast2/popup.rb:235:in `event_loop'
     # /usr/share/YaST2/lib/yast2/popup.rb:90:in `show'
     # /usr/share/YaST2/modules/Report.rb:562:in `Error'
     # /usr/share/YaST2/lib/yast2/execute.rb:235:in `rescue in popup_error'
     # /usr/share/YaST2/lib/yast2/execute.rb:230:in `popup_error'
     # /usr/share/YaST2/lib/yast2/execute.rb:182:in `run'
     # /usr/share/YaST2/lib/yast2/execute.rb:133:in `run_or_chain'
     # /usr/share/YaST2/lib/yast2/execute.rb:88:in `on_target!'
     # /usr/share/YaST2/lib/yast2/execute.rb:75:in `on_target'
     # /usr/share/YaST2/lib/y2firewall/firewalld/api.rb:201:in `run_command'
     # /usr/share/YaST2/lib/y2firewall/firewalld/api.rb:215:in `string_command'
     # /usr/share/YaST2/lib/y2firewall/firewalld/api/zones.rb:32:in `zones'
     # /usr/share/YaST2/lib/y2firewall/firewalld.rb:99:in `read'
     # ./src/modules/Nfs.rb:297:in `Read'
     # ./test/nfs_test.rb:56:in `mock_entries'
     # ./test/nfs_test.rb:159:in `block (3 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # Cheetah::ExecutionFailed:
     #   Execution of "firewall-offline-cmd --get-zones" failed with status 255: You need to be root to run /usr/bin/firewall-offline-cmd..
     #   /usr/share/YaST2/lib/yast2/execute.rb:179:in `block in run'
```

## Solution

- Call a helper method defined in the code above, it mocks all read calls

## Testing

- Tested manually, now the unit test passes
