### PR TITLE
Backport SP6

### DIFF
--- a/package/yast2-nfs-client.changes
+++ b/package/yast2-nfs-client.changes
@@ -2,6 +2,7 @@
 Fri Sep 01 19:57:03 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
 
 - Branch package for SP6 (bsc#1208913)
+- 4.6.2
 
 -------------------------------------------------------------------
 Tue Mar  7 12:27:28 UTC 2023 - Ladislav Slezák <lslezak@suse.com>

--- a/package/yast2-nfs-client.spec
+++ b/package/yast2-nfs-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-nfs-client
-Version:        4.6.0
+Version:        4.6.2
 Release:        0
 Url:            https://github.com/yast/yast-nfs-client
 Summary:        YaST2 - NFS Configuration


### PR DESCRIPTION
## Problem

SLE 15 SP6 branch is based on SLE15 SP5 maintenance branch. So fixes done in master can be sometimes useful also for SP6.

## Solution

Just bump version as all fixes are already in SP5 under different version.