### PR TITLE
Removed support for setting idmapd domain

### DIFF
--- a/package/yast2-nfs-client.changes
+++ b/package/yast2-nfs-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jun 14 09:12:20 UTC 2024 - Michal Filka <mfilka@suse.com>
+
+- bsc#1218158
+  - dropped reading / writing domain from / to idmapd.conf 
+- 5.0.1
+
+-------------------------------------------------------------------
 Wed Aug 30 20:16:10 UTC 2023 - Josef Reidinger <jreidinger@suse.cz>
 
 - 5.0.0 (bsc#1185510)

--- a/package/yast2-nfs-client.spec
+++ b/package/yast2-nfs-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-nfs-client
-Version:        5.0.0
+Version:        5.0.1
 Release:        0
 Url:            https://github.com/yast/yast-nfs-client
 Summary:        YaST2 - NFS Configuration

--- a/src/autoyast-rnc/nfs.rnc
+++ b/src/autoyast-rnc/nfs.rnc
@@ -27,7 +27,6 @@ nfs_sle11_sp2 =
 nfs_global_options_content = (
     element enable_nfs4 { BOOLEAN }? &
     element enable_nfs_gss { BOOLEAN }? &
-    element idmapd_domain { text }?
 )
 
 nfs_os113_123 =

--- a/src/include/nfs/ui.rb
+++ b/src/include/nfs/ui.rb
@@ -78,9 +78,7 @@ module Yast
       @help_text2 = Ops.add(
         _(
           "<p>If you need to access NFSv4 shares (NFSv4 is a newer version of the NFS\n" \
-          "protocol), check the <b>NFS version</b> option. In that case, you might need\n" \
-          "to supply an specific <b>NFSv4 Domain Name</b> required for the correct setting\n" \
-          "of file/directory access rights.</p>\n"
+          "protocol), check the <b>NFS version</b> option."
         ),
         Ops.get_string(@fw_cwm_widget, "help", "")
       )
@@ -220,7 +218,6 @@ module Yast
       settings_content = VBox(
         HBox(
           Left(CheckBox(Id(:enable_nfs4), Opt(:notify), _("Enable NFSv4"))),
-          Left(InputField(Id(:nfs4_domain), _("NFSv4 Domain Name"))),
           HStretch()
         ),
         VSpacing(1),
@@ -329,8 +326,7 @@ module Yast
           Nfs.SetModified
         end
       when :enable_nfs4
-        enabled = Convert.to_boolean(UI.QueryWidget(Id(:enable_nfs4), :Value))
-        UI.ChangeWidget(Id(:nfs4_domain), :Enabled, enabled)
+        Convert.to_boolean(UI.QueryWidget(Id(:enable_nfs4), :Value))
         Nfs.SetModified
       when :settings
         SaveFstabEntries()

--- a/src/include/nfs/ui.rb
+++ b/src/include/nfs/ui.rb
@@ -259,8 +259,6 @@ module Yast
     def InitSettings
       CWMFirewallInterfaces.OpenFirewallInit(@fw_cwm_widget, "")
       UI.ChangeWidget(Id(:enable_nfs4), :Value, Nfs.nfs4_enabled != false)
-      UI.ChangeWidget(Id(:nfs4_domain), :Enabled, Nfs.nfs4_enabled != false)
-      UI.ChangeWidget(Id(:nfs4_domain), :Value, Nfs.idmapd_domain)
       UI.ChangeWidget(Id(:enable_nfs_gss), :Value, Nfs.nfs_gss_enabled != false)
 
       nil
@@ -280,9 +278,6 @@ module Yast
       )
       Nfs.nfs_gss_enabled = Convert.to_boolean(
         UI.QueryWidget(Id(:enable_nfs_gss), :Value)
-      )
-      Nfs.idmapd_domain = Convert.to_string(
-        UI.QueryWidget(Id(:nfs4_domain), :Value)
       )
 
       nil

--- a/test/nfs_test.rb
+++ b/test/nfs_test.rb
@@ -31,7 +31,6 @@ describe "Yast::Nfs" do
   def allow_read_side_effects
     allow(subject).to receive(:ReadNfs4)
     allow(subject).to receive(:ReadNfsGss)
-    allow(subject).to receive(:ReadIdmapd)
     allow(subject).to receive(:FindPortmapper).and_return("rpcbind")
     allow(subject).to receive(:firewalld).and_return(firewalld)
     allow(firewalld).to receive(:read)
@@ -96,7 +95,7 @@ describe "Yast::Nfs" do
       [
         {
           "enable_nfs_gss" => true,
-          "idmapd_domain"  => "example.com"
+          "enable_nfs4"    => "example.com"
         },
         {
           "server_path" => "data.example.com:/mirror",
@@ -127,7 +126,6 @@ describe "Yast::Nfs" do
       it "imports the global options when defined as a map" do
         subject.Import(profile_SLE11)
         expect(subject.nfs_gss_enabled).to eql(true)
-        expect(subject.idmapd_domain).to eql("example.com")
       end
 
       context "and some of the entries defines the nfs_version=4 in the nfs_options" do
@@ -159,14 +157,12 @@ describe "Yast::Nfs" do
       mock_entries
       subject.nfs4_enabled = true
       subject.nfs_gss_enabled = false
-      subject.idmapd_domain = "example.com"
     end
 
     let(:expected_profile) do
       {
         "enable_nfs4"    => true,
         "enable_nfs_gss" => false,
-        "idmapd_domain"  => "example.com",
         "nfs_entries"    => [
           {
             "server_path" => "nfs.example.com:/foo",
@@ -262,8 +258,6 @@ describe "Yast::Nfs" do
         .with(path(".target.mkdir"), anything).and_return(true)
       allow(Yast::SCR).to receive(:Write)
         .with(path_matching(/^\.sysconfig\.nfs/), any_args)
-      allow(Yast::SCR).to receive(:Write)
-        .with(path_matching(/^\.etc\.idmapd_conf/), any_args)
       allow(firewalld).to receive(:installed?).and_return(true)
       allow(firewalld).to receive(:read)
       allow(firewalld).to receive(:write_only)


### PR DESCRIPTION
## Problem

Handling of configuration of idmapd was causing some troubles with the usr-merge feature.

As the support for idmapd was very poor (in fact only reading / writing domain) and the yast is at the end of its way anyway we decided to remove this stuff from yast-nfs-client. User is expected to do necessary steps on his own.

- [bsc#1218158](https://bugzilla.suse.com/show_bug.cgi?id=1218158)
-  See https://github.com/yast/yast-nfs-server/pull/56 for server related update


## Solution

No support for idmapd configuration
